### PR TITLE
Suporte para Python2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: python
 
 matrix:
     include:
+      - python: 2.7
+        env: TOX_ENV=py27
       - python: 3.3
         env: TOX_ENV=py33
       - python: 3.4
@@ -15,7 +17,7 @@ matrix:
         env: TOX_ENV=py36
       - python: 3.5
         env: TOX_ENV=flake8
-      - python: 3.5
+      - python: 2.7
         env: TOX_ENV=pypi
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,7 +26,7 @@ Corrigindo erros
 ~~~~~~~~~~~~~~~~
 
 Busque na lista de *issues* por aquelas com a tag *Bug*.
-Qualquer *issue* marcada com "Bug" está aberta para quem quiser corrigí-la.
+Qualquer *issue* marcada com "Bug" está aberta para quem quiser corrigi-la.
 
 Adicionando novos recursos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -38,7 +38,7 @@ Melhorando a documentação
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A documentação da PyCEPCorreios sempre pode ser melhorada, seja como parte do
-da documentação oficial do PyCEPCorreios, em docstrings, ou mesmo na web em postagens de blog,
+da documentação oficial do PyCEPCorreios, em *docstrings*, ou mesmo na web em postagens de blog,
 artigos e etc. Então caso você tenha escrito alguma postagem sobre a PyCEPCorreios, por favor,
 me avise para que a mesma seja incluída aqui como referência.
 
@@ -66,8 +66,8 @@ Pronto para contribuir? Veja como configurar `pycep_correios` para desenvolvimen
 3. Instale sua cópia local em um *virtualenv*. Supondo que você tenha instalado o *virtualenv*, é assim que você configura a seu *fork* para o desenvolvimento local::
 
     $ cd pycep-correios
-    $ virtualenv -p python3 env
-    $ pip3 install -r requirements.txt
+    $ virtualenv env
+    $ pip install -r requirements.txt
 
 4. Crie uma *branch* para desenvolvimento::
 
@@ -95,4 +95,4 @@ Após enviar um pedido de *Pull Request*, verifique se ele atende a essas diretr
 
 1. O pedido de *Pull Request* deve incluir testes, quando for uma nova *feature*.
 2. Se o *Pull Request* adicionar funcionalidades, a documentação deve ser atualizada adicionado detalhes de uso da nova funcionalidade.
-3. O pedido de *Pull Request* deve funcionar para o Python 3.3, 3.4, 3.5 e 3.6. Verificar https://travis-ci.org/mstuttgart/pycep-correios/pull_requests e certifique-se de que os testes passem para todas as versões do Python suportadas.
+3. O pedido de *Pull Request* deve funcionar para o Python 2.7+ e 3.3+. Verificar https://travis-ci.org/mstuttgart/pycep-correios/pull_requests e certifique-se de que os testes passem para todas as versões do Python suportadas.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 Histórico
 =========
 
+2.1.0 (2017-07-01)
+------------------
+
+* Adicionado suporte para Python 2.7+
+* Ajustes e correções na documentação
+
 2.0.0 (2017-06-20)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,8 @@ PyCEPCorreios
     :target: https://landscape.io/github/mstuttgart/pycep-correios/develop
 
 .. image:: https://img.shields.io/requires/github/mstuttgart/pycep-correios.svg?style=flat-square
-    :target: https://github.com/mstuttgart/pycep-correios
+    :target: https://requires.io/github/mstuttgart/pycep-correios/requirements/?branch=develop
+    :alt: Requirements Status
 
 .. image:: https://img.shields.io/pypi/v/pycep-correios.svg?style=flat-square
     :target: https://pypi.python.org/pypi/pycep-correios
@@ -46,9 +47,9 @@ O PyCEP Correios pode ser facilmente instalado com o comando a seguir:
 
 .. code:: bash
 
-    pip3 install pycep-correios
+    pip install pycep-correios
 
-Atualmente, a PyCEPCorreios possui suporte apenas para Python 3+.
+Atualmente, a PyCEPCorreios possui suporte para Python 2.7+ e 3.3+.
 
 Como usar
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,8 @@ Bem vindo a PyCEPCorreios!
 .. image:: https://img.shields.io/pypi/l/pycep-correios.svg?style=flat-square
     :target: https://github.com/mstuttgart/pycep-correios/blob/develop/LICENSE
 
-API para consulta de CEP diretamente no *webservice* dos Correios. O *webservice* utilizado é
-do serviço SIGEPWeb, fornecido pelos correios.
+A PyCEPCorreios é uma API para consulta de CEP diretamente no *webservice* dos Correios.
+O *webservice* em questão utilizado para cunsulta de CEP é o *webservice* do serviço SIGEPWeb, fornecido pelos correios.
 
 A PyCEPCorreios possui as seguintes funcionalidades:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,6 +4,8 @@
 Instalação
 ==========
 
+Atualmente, a PyCEPCorreios possui suporte para Python 2.7+ e 3.3+.
+
 Versão estável
 --------------
 
@@ -11,7 +13,7 @@ Para instalar PyCEPCorreios, execute este comando no seu terminal:
 
 .. code-block:: console
 
-    $ pip3 install pycep_correios
+    $ pip install pycep_correios
 
 Este é o método recomendado para instalar a PyCEPCorreios. Desse modo sempre será instalado a versão mais recente.
 
@@ -36,7 +38,7 @@ Uma vez que você tenha uma cópia do código fonte, você pode instalá-lo com:
 
 .. code-block:: console
 
-    $ python3 setup.py install
+    $ python setup.py install
 
 
 .. _aqui: https://github.com/mstuttgart/pycep-correios

--- a/pycep_correios/__init__.py
+++ b/pycep_correios/__init__.py
@@ -20,5 +20,4 @@ __all__ = [
     'formatar_cep',
     'validar_cep',
     'CEPInvalido',
-    'CEPInvalido',
 ]

--- a/pycep_correios/__version__.py
+++ b/pycep_correios/__version__.py
@@ -2,7 +2,7 @@
 
 __title__ = 'pycep_correios'
 __description__ = 'API para busca de CEP no webservice dos Correios'
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 __url__ = 'https://github.com/mstuttgart/pycep_correios'
 __download_url__ = 'https://github.com/mstuttgart/pycep_correios'
 __author__ = 'Michell Stuttgart Faria'

--- a/pycep_correios/cliente.py
+++ b/pycep_correios/cliente.py
@@ -9,7 +9,7 @@ URL = 'https://apps.correios.com.br/SigepMasterJPA/AtendeClienteService/' \
       'AtendeCliente?wsdl'
 
 
-def consultar_cep(cep: str) -> dict:
+def consultar_cep(cep):
     """Retorna o endereço correspondente ao número de CEP informado.
 
     :param cep: CEP a ser consultado.
@@ -32,7 +32,7 @@ def consultar_cep(cep: str) -> dict:
             raise CEPInvalido(msg)
 
 
-def formatar_cep(cep: str) -> str:
+def formatar_cep(cep):
     """Formata CEP, removendo pontuação
 
     :param cep: CEP a ser formatado
@@ -43,7 +43,7 @@ def formatar_cep(cep: str) -> str:
     return cep
 
 
-def validar_cep(cep: str) -> bool:
+def validar_cep(cep):
     """Verifica se o CEP informado possui 8 digitos e é constituído apenas de
     números
 

--- a/pycep_correios/parser.py
+++ b/pycep_correios/parser.py
@@ -4,7 +4,7 @@ import xml.etree.cElementTree as Et
 from jinja2 import Environment, PackageLoader
 
 
-def parse_resposta(xml: str) -> dict:
+def parse_resposta(xml):
     """Extrai os endereço do xml retornado pelo webservice
 
     :param xml: xml retornado pelo webservice
@@ -27,7 +27,7 @@ def parse_resposta(xml: str) -> dict:
     return endereco
 
 
-def parse_resposta_com_erro(xml: str) -> str:
+def parse_resposta_com_erro(xml):
     """Realiza a leitura do XML retornado pelo servidor e extrai a mensagem de
     erro
 
@@ -37,7 +37,7 @@ def parse_resposta_com_erro(xml: str) -> str:
     return Et.fromstring(xml).findtext('.//faultstring')
 
 
-def monta_requisicao(cep: str) -> str:
+def monta_requisicao(cep):
     """Gera o XML utilizado para realizar a requisição ao webservice
 
     :param cep: CEP a ser consultado

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ coveralls==1.1
 Sphinx==1.6.2
 requests==2.18.1
 Jinja2==2.9.6
+mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ version_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                             '__version__.py')
 
 about = {}
-with open(version_path, 'r', 'utf-8') as f:
+with open(version_path, 'r') as f:
     exec(f.read(), about)
 
-with open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read()
 
 requirements = [
@@ -28,6 +28,7 @@ requirements = [
 test_requirements = [
     'coveralls == 1.1',
     'flake8 == 3.3.0',
+    'mock==2.0.0',
 ]
 
 setup(
@@ -56,6 +57,7 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: Portuguese',
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/test_cliente.py
+++ b/tests/test_cliente.py
@@ -79,7 +79,6 @@ class TestCorreios(TestCase):
         template = self.env.get_template('consultacep.xml')
         xml = template.render(cep='37503005')
         xml = (xml.replace('\n', '')).replace('\t', '')
-        xml = xml
 
         self.assertEqual(xml, parser.monta_requisicao(cep='37503005'))
 

--- a/tests/test_cliente.py
+++ b/tests/test_cliente.py
@@ -1,7 +1,11 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from unittest import mock, TestCase
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from unittest import TestCase
 from jinja2 import Environment, PackageLoader
 
 from pycep_correios import consultar_cep, formatar_cep, validar_cep
@@ -14,14 +18,14 @@ class TestCorreios(TestCase):
     def setUp(self):
 
         self.expected_address = {
-            'bairro': 'Santo Antônio',
-            'cep': '37503130',
-            'cidade': 'Itajubá',
-            'end': 'Rua Geraldino Campista',
-            'id': '0',
-            'uf': 'MG',
-            'complemento': '',
-            'complemento2': '- até 214/215',
+            'bairro': u'Santo Antônio',
+            'cep': u'37503130',
+            'cidade': u'Itajubá',
+            'end': u'Rua Geraldino Campista',
+            'id': u'0',
+            'uf': u'MG',
+            'complemento': u'',
+            'complemento2': u'- até 214/215',
         }
 
         self.env = Environment(loader=PackageLoader('tests', 'templates'))
@@ -29,10 +33,12 @@ class TestCorreios(TestCase):
         template = self.env.get_template('resposta.xml')
         xml = template.render(**self.expected_address)
         self.response_xml = (xml.replace('\n', '')).replace('\t', '')
+        self.response_xml = self.response_xml.encode('utf8')
 
         template = self.env.get_template('resposta_error.xml')
         xml = template.render()
         self.response_xml_error = (xml.replace('\n', '')).replace('\t', '')
+        self.response_xml_error = self.response_xml_error.encode('utf8')
 
     @mock.patch('requests.post')
     def test_consultar_cep(self, mock_api_call):
@@ -73,6 +79,7 @@ class TestCorreios(TestCase):
         template = self.env.get_template('consultacep.xml')
         xml = template.render(cep='37503005')
         xml = (xml.replace('\n', '')).replace('\t', '')
+        xml = xml
 
         self.assertEqual(xml, parser.monta_requisicao(cep='37503005'))
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33, py34, py35, py36, flake8, pypi
+envlist = py27, py33, py34, py35, py36, flake8, pypi
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Ajustar a PyCEPCorreios para que a mesma ofereça suporte para Python 2.7.

- [x] Atualizar dependências
- [x] Atualizar testes
- [x] Atualizar base de código
- [x] Atualizar documentação

close https://github.com/mstuttgart/pycep-correios/issues/8