### PR TITLE
remover caracteres não numéricos do cep

### DIFF
--- a/pycep_correios/cliente.py
+++ b/pycep_correios/cliente.py
@@ -41,6 +41,8 @@ def formatar_cep(cep):
     :param cep: CEP a ser formatado
     :returns: string contendo o CEP formatado
     """
+    if not isinstance(cep, six.string_types) or not cep:
+        raise ValueError('cep deve ser uma string nao vazia')
     return CARACTERES_NUMERICOS.sub('', cep)
 
 

--- a/pycep_correios/cliente.py
+++ b/pycep_correios/cliente.py
@@ -43,7 +43,7 @@ def formatar_cep(cep):
     :returns: string contendo o CEP formatado
     """
     if not isinstance(cep, six.string_types) or not cep:
-        raise ValueError('cep deve ser uma string nao vazia contendo somente numeros')
+        raise ValueError('cep deve ser uma string nao vazia contendo somente numeros')  # noqa: E501
     return CARACTERES_NUMERICOS.sub('', cep)
 
 

--- a/pycep_correios/cliente.py
+++ b/pycep_correios/cliente.py
@@ -2,6 +2,7 @@
 
 import re
 import requests
+import six
 
 from .excecoes import CEPInvalido
 from .parser import parse_resposta_com_erro, parse_resposta, monta_requisicao
@@ -42,7 +43,7 @@ def formatar_cep(cep):
     :returns: string contendo o CEP formatado
     """
     if not isinstance(cep, six.string_types) or not cep:
-        raise ValueError('cep deve ser uma string nao vazia')
+        raise ValueError('cep deve ser uma string nao vazia contendo somente numeros')
     return CARACTERES_NUMERICOS.sub('', cep)
 
 

--- a/pycep_correios/cliente.py
+++ b/pycep_correios/cliente.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import re
 import requests
 
 from .excecoes import CEPInvalido
 from .parser import parse_resposta_com_erro, parse_resposta, monta_requisicao
+
+CARACTERES_NUMERICOS = re.compile(r'[^0-9]')
 
 URL = 'https://apps.correios.com.br/SigepMasterJPA/AtendeClienteService/' \
       'AtendeCliente?wsdl'
@@ -33,14 +36,12 @@ def consultar_cep(cep):
 
 
 def formatar_cep(cep):
-    """Formata CEP, removendo pontuação
+    """Formata CEP, removendo qualquer caractere nao numerico
 
     :param cep: CEP a ser formatado
     :returns: string contendo o CEP formatado
     """
-    cep = cep.replace('-', '')
-    cep = cep.replace('.', '')
-    return cep
+    return CARACTERES_NUMERICOS.sub('', cep)
 
 
 def validar_cep(cep):

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read()
 
 requirements = [
-    'requests == 2.18.1',
-    'Jinja2 == 2.9.6',
+    'requests >= 2.18.1',
+    'Jinja2 >= 2.9.6',
+    'six>=1.10'
 ]
 
 test_requirements = [

--- a/tests/test_cliente.py
+++ b/tests/test_cliente.py
@@ -69,6 +69,15 @@ class TestCorreios(TestCase):
     def test_formatar_cep(self):
         self.assertRaises(AttributeError, formatar_cep, 37503003)
         self.assertEqual(formatar_cep('37.503-003'), '37503003')
+        self.assertEqual(formatar_cep('   37.503-003'), '37503003')
+        self.assertEqual(formatar_cep('37 503-003'), '37503003')
+        self.assertEqual(formatar_cep('37.503&003saasd'), '37503003')
+        self.assertEqual(formatar_cep('\n \r 37.503-003'), '37503003')
+        self.assertEqual(formatar_cep('\n \r 37.503-003'), '37503003')
+        # ponto e virgula
+        self.assertEqual(formatar_cep('37.503-003;'), '37503003')
+        # Unicode Greek Question Mark
+        self.assertEqual(formatar_cep(u'37.503-003;'), '37503003')
 
     def test_validar_cep(self):
         self.assertRaises(AttributeError, validar_cep, 37503003)

--- a/tests/test_cliente.py
+++ b/tests/test_cliente.py
@@ -67,7 +67,11 @@ class TestCorreios(TestCase):
         self.assertRaises(CEPInvalido, consultar_cep, '00000000')
 
     def test_formatar_cep(self):
-        self.assertRaises(AttributeError, formatar_cep, 37503003)
+        self.assertRaises(ValueError, formatar_cep, 37503003)
+        self.assertRaises(ValueError, formatar_cep, '')
+        self.assertRaises(ValueError, formatar_cep, None)
+        self.assertRaises(ValueError, formatar_cep, False)
+        self.assertRaises(ValueError, formatar_cep, True)
         self.assertEqual(formatar_cep('37.503-003'), '37503003')
         self.assertEqual(formatar_cep('   37.503-003'), '37503003')
         self.assertEqual(formatar_cep('37 503-003'), '37503003')

--- a/tests/test_cliente.py
+++ b/tests/test_cliente.py
@@ -84,9 +84,12 @@ class TestCorreios(TestCase):
         self.assertEqual(formatar_cep(u'37.503-003;'), '37503003')
 
     def test_validar_cep(self):
-        self.assertRaises(AttributeError, validar_cep, 37503003)
+        self.assertRaises(ValueError, validar_cep, 37503003)
+        self.assertRaises(ValueError, validar_cep, '')
         self.assertIs(validar_cep('37.503-003'), True)
         self.assertIs(validar_cep('37.503-00'), False)
+        self.assertIs(validar_cep('   37.503-003'), True)
+        self.assertIs(validar_cep('37.503&003saasd'), True)
 
     def test_monta_requisicao(self):
         template = self.env.get_template('consultacep.xml')


### PR DESCRIPTION
pequena melhoria em `formatar_cep`. Agora ele remove todos os caracteres não numericos, em vez de somente os caracteres `.` e `-`

ps: Isto quebra compatibilidade porque a exception lançada por `formatar_cep` mudou de `AttributeError` para `ValueError`

Tambem removi a trava der versão das dependências, porque se ficasse daquela forma, poderia acabar forçando um upgrade ou downgrade de versão daquelas bibliotecas e assim acabar quebrando a instalação existente.
Eu sugeriria verificar se ele também funciona com versão mais antigas das dependências, de modo a limitar a versão das dependências por baixo