### PR TITLE
[FIX] Chave correta para Retorno de CEP inválido

### DIFF
--- a/pycep_correios/client.py
+++ b/pycep_correios/client.py
@@ -135,7 +135,7 @@ def get_address_from_cep(cep):
         if response.status_code == 200:
             address = json.loads(response.text)
 
-            if 'error' in address and address['error']:
+            if address.get('erro'):
                 raise exceptions.BaseException(message='Other error')
 
             return {


### PR DESCRIPTION
[FIX] Retorno de CEP inválido, usa json com chave "erro" ao invés de "error"

Se acessar a API com um CEP inválido, o retorno é um JSON avisando do erro.

No código a validação do JSON para identificar se a consulta retornou ou não com erro, utiliza 
a palavra "error":

```
if 'error' in address
```

Mas o retorno da API utiliza a palavra "erro":

http://viacep.com.br/ws/00000000/json


Vlw!